### PR TITLE
Update installer (.NET 4.6.1, WiX 3.11, Visual Studio 2017)

### DIFF
--- a/build/TestInstallerBuild.bat
+++ b/build/TestInstallerBuild.bat
@@ -1,4 +1,9 @@
-call "c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat"
+setlocal
+@set PATH=C:\Program Files (x86)\Microsoft Visual Studio\Installer;%PATH%
+for /f "usebackq delims=" %%i in (`vswhere -latest -requires Microsoft.Component.MSBuild -property installationPath`) do (
+	set InstallDir=%%i
+)
+call "%InstallDir%\VC\Auxiliary\Build\vcvarsall.bat" x86
 
 pushd .
 MSbuild /target:installer /property:teamcity_build_checkoutDir=..\  /property:teamcity_dotnet_nunitlauncher_msbuild_task="notthere" /property:BUILD_NUMBER="*.*.6.789" /property:Minor="1"

--- a/build/build.proj
+++ b/build/build.proj
@@ -17,40 +17,40 @@
 		<ApplicationName>PdfDroplet</ApplicationName>
 		<Configuration>Release</Configuration>
 	</PropertyGroup>
-  
-  <Target Name="VersionNumbers">
-    <Message Text="BUILD_NUMBER: $(BUILD_NUMBER)" Importance="high"/>
 
-    <Split Input="$(BUILD_NUMBER)" Delimiter="." OutputSubString="2">
-      <Output TaskParameter="ReturnValue" PropertyName="BuildCounter" />
-    </Split>
+	<Target Name="VersionNumbers">
+		<Message Text="BUILD_NUMBER: $(BUILD_NUMBER)" Importance="high"/>
 
-    <Message Text="BuildCounter: $(BuildCounter)" Importance="high"/>
+		<Split Input="$(BUILD_NUMBER)" Delimiter="." OutputSubString="2">
+			<Output TaskParameter="ReturnValue" PropertyName="BuildCounter" />
+		</Split>
 
-    <!-- Note, after some thought, we've decided this is the best place to keep the version number (not on TeamCity, not in the assemblies).     -->
-    <CreateProperty Value="2.4.$(BuildCounter)">
-      <Output PropertyName="Version" TaskParameter="Value"/>
-    </CreateProperty>
-   
-    <Message Text="Version: $(Version)" Importance="high"/>
-  </Target>
-   
-   <!-- Note: Mono xbuild doesn't support ItemGroup inside Target -->
-  <ItemGroup>
-    <AssemblyInfoFiles Include="$(RootDir)/src/**/assemblyinfo.cs"/>
-  </ItemGroup>
+		<Message Text="BuildCounter: $(BuildCounter)" Importance="high"/>
 
-  <Target Name="SetAssemblyVersion" DependsOnTargets ="VersionNumbers">
-      <StampAssemblies Version="$(Version)" InputAssemblyPaths="@(AssemblyInfoFiles)" />
-    </Target>
+		<!-- Note, after some thought, we've decided this is the best place to keep the version number (not on TeamCity, not in the assemblies). -->
+		<CreateProperty Value="2.4.$(BuildCounter)">
+			<Output PropertyName="Version" TaskParameter="Value"/>
+		</CreateProperty>
+
+		<Message Text="Version: $(Version)" Importance="high"/>
+	</Target>
+
+	<!-- Note: Mono xbuild doesn't support ItemGroup inside Target -->
+	<ItemGroup>
+		<AssemblyInfoFiles Include="$(RootDir)/src/**/assemblyinfo.cs"/>
+	</ItemGroup>
+
+	<Target Name="SetAssemblyVersion" DependsOnTargets ="VersionNumbers">
+		<StampAssemblies Version="$(Version)" InputAssemblyPaths="@(AssemblyInfoFiles)" />
+	</Target>
 
 
-  <Target Name="Build" DependsOnTargets="SetAssemblyVersion">
-    <MSBuild Projects="$(RootDir)/$(Solution)"
-             Targets="Rebuild"
-             Properties="Configuration=$(Configuration)" />
-    <Message Text="Build Complete"/>
-  </Target>
+	<Target Name="Build" DependsOnTargets="SetAssemblyVersion">
+		<MSBuild Projects="$(RootDir)/$(Solution)"
+			 Targets="Rebuild"
+			 Properties="Configuration=$(Configuration)" />
+		<Message Text="Build Complete"/>
+	</Target>
 
 
 	<Target Name="Test" DependsOnTargets="Build">
@@ -63,78 +63,62 @@
 			NUnitVersion="NUnit-2.5.5" />
 	</Target>
 
-  <Target Name="MakeDownloadPointers" DependsOnTargets="VersionNumbers" >
+	<Target Name="MakeDownloadPointers" DependsOnTargets="VersionNumbers" >
 
-    <!-- copy it so we aren't modifying the original, which then is a pain on dev machines -->
-    <Copy SourceFiles ="$(RootDir)\src\Installer\DownloadPointers.htm"
-           DestinationFolder ="$(RootDir)\output\Installer"/>
-    
-    <!-- replace some parts of the file with the version number & date -->
-    
-    <FileUpdate File="$(RootDir)\output\Installer\DownloadPointers.htm"
-                 DatePlaceholder='DEV_RELEASE_DATE'
-                Regex='DEV_VERSION_NUMBER'
-                 ReplacementText ="$(Version)" />
+		<!-- copy it so we aren't modifying the original, which then is a pain on dev machines -->
+		<Copy SourceFiles ="$(RootDir)\src\Installer\DownloadPointers.htm"
+			DestinationFolder ="$(RootDir)\output\Installer"/>
 
+		<!-- replace some parts of the file with the version number & date -->
+		<FileUpdate File="$(RootDir)\output\Installer\DownloadPointers.htm"
+				DatePlaceholder='DEV_RELEASE_DATE'
+				Regex='DEV_VERSION_NUMBER'
+				ReplacementText ="$(Version)" />
 
-    
-    <!-- push up to the web so that on our downloads page, we can give a link to the latest version -->
-     
-    <Message Text="Attempting rsync of DownloadPointers.htm" Importance="high"/>
-    <Exec Command ='"c:\program files\cwRsync\bin\rsync.exe" -vz -p --chmod=ug+rw,o+r -e"\"c:\program files\cwRsync\bin\ssh\" -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=C:\BuildAgent\conf\bob.key -l bob"  "../output/installer/DownloadPointers.htm" bob@palaso.org:/var/www/virtual/palaso.org/pdfdroplet/htdocs/files/DownloadPointers.htm' /> 
-  </Target>
-  
+		<!-- push up to the web so that on our downloads page, we can give a link to the latest version -->
+		<Message Text="Attempting rsync of DownloadPointers.htm" Importance="high"/>
+		<Exec Command ='"c:\program files\cwRsync\bin\rsync.exe" -vz -p --chmod=ug+rw,o+r -e"\"c:\program files\cwRsync\bin\ssh\" -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=C:\BuildAgent\conf\bob.key -l bob"  "../output/installer/DownloadPointers.htm" bob@palaso.org:/var/www/virtual/palaso.org/pdfdroplet/htdocs/files/DownloadPointers.htm' /> 
+	</Target>
 
+	<Target Name="Upload" DependsOnTargets="VersionNumbers; Installer" >
+		<Message Text="Attempting rsync of PdfDropletInstaller-$(Version).msi" Importance="high"/>
 
-  <Target Name="Upload" DependsOnTargets="VersionNumbers; Installer" >
-    <Message Text="Attempting rsync of PdfDropletInstaller-$(Version).msi" Importance="high"/>
+		<Exec Command ='"c:\program files\cwRsync\bin\rsync.exe" -vz -p --chmod=ug+rw,o+r -e"\"c:\program files\cwRsync\bin\ssh\" -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=C:\BuildAgent\conf\bob.key -l bob"  "../output/installer/PdfDropletInstaller-$(Version).msi" bob@palaso.org:/var/www/virtual/palaso.org/pdfdroplet/htdocs/files/PdfDropletInstaller-$(Version).msi' /> 
 
-    <Exec Command ='"c:\program files\cwRsync\bin\rsync.exe" -vz -p --chmod=ug+rw,o+r -e"\"c:\program files\cwRsync\bin\ssh\" -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=C:\BuildAgent\conf\bob.key -l bob"  "../output/installer/PdfDropletInstaller-$(Version).msi" bob@palaso.org:/var/www/virtual/palaso.org/pdfdroplet/htdocs/files/PdfDropletInstaller-$(Version).msi' /> 
-
-    <CallTarget Targets ='MakeDownloadPointers'/>
-  </Target>
-
-   
-  <Target Name="Installer" DependsOnTargets="VersionNumbers; MakeWixForDistFiles; Build ">
-    
-    <!-- set the version number in the installer configuration program.  Perhaps there's a way to just send in the variables rather than this brute-force
-		changing of the script, but I haven't figured that out. -->
-    
-    <FileUpdate File="$(RootDir)\src\Installer\Installer.wxs" Regex='Property_ProductVersion = ".*"'
-                ReplacementText ="Property_ProductVersion = &quot;$(Version)&quot;" />
+		<CallTarget Targets ='MakeDownloadPointers'/>
+	</Target>
 
 
-    <Message Text="Making Installer Version: $(Version)" Importance="high"  />
+	<Target Name="Installer" DependsOnTargets="VersionNumbers; MakeWixForDistFiles; Build ">
+		<Message Text="Making Installer Version: $(Version)" Importance="high"/>
 
-    <MSBuild Projects="$(RootDir)\src\Installer\Installer.wixproj"/>
-
-    
-    <!-- remove an existing one with the same name, if necessary -->
-    <Delete Files="$(RootDir)\output\installer\PdfDropletInstaller-$(Version).msi" TreatErrorsAsWarnings="false" />
-
-    <Copy SourceFiles="$(RootDir)\output\installer\PdfDropletInstaller.msi"
-          DestinationFiles="$(RootDir)\output\installer\PdfDropletInstaller-$(Version).msi"
-          />
-
-    <!-- remove the installer which has no version number (wouldn't need this if the copy above was a move, instead) -->
-    <Delete Files="$(RootDir)\output\installer\PdfDropletInstaller.msi" TreatErrorsAsWarnings="false" />
-
-  </Target>
+		<MSBuild Projects="$(RootDir)\src\Installer\Installer.wixproj" Properties="DefineConstants=Property_ProductVersion=$(Version)"/>
 
 
+		<!-- remove an existing one with the same name, if necessary -->
+		<Delete Files="$(RootDir)\output\installer\PdfDropletInstaller-$(Version).msi" TreatErrorsAsWarnings="false" />
 
-  <Target Name="MakeWixForDistFiles">
-    <MakeDir Directories="$(RootDir)\output\Installer\"/>
-    
-    <MakeWixForDirTree
-                DirectoryReferenceId="ProgramDir"
-            		ComponentGroupId="DistFiles"
-				        RootDirectory="$(RootDir)\DistFiles"
-                OutputFilePath="$(RootDir)\output\Installer\GeneratedDistFiles.wxs"
-                MatchRegExPattern=".*"
+		<Copy SourceFiles="$(RootDir)\output\installer\PdfDropletInstaller.msi"
+			DestinationFiles="$(RootDir)\output\installer\PdfDropletInstaller-$(Version).msi"
+			/>
+
+		<!-- remove the installer which has no version number (wouldn't need this if the copy above was a move, instead) -->
+		<Delete Files="$(RootDir)\output\installer\PdfDropletInstaller.msi" TreatErrorsAsWarnings="false" />
+
+	</Target>
+
+	<Target Name="MakeWixForDistFiles">
+		<MakeDir Directories="$(RootDir)\output\Installer\"/>
+
+		<MakeWixForDirTree
+				DirectoryReferenceId="ProgramDir"
+					ComponentGroupId="DistFiles"
+						RootDirectory="$(RootDir)\DistFiles"
+				OutputFilePath="$(RootDir)\output\Installer\GeneratedDistFiles.wxs"
+				MatchRegExPattern=".*"
 				>
-      <!--what does this do?-->
-      <Output TaskParameter="OutputFilePath" ItemName="Compile" />
-    </MakeWixForDirTree>
-  </Target>
+			<!--what does this do?-->
+			<Output TaskParameter="OutputFilePath" ItemName="Compile" />
+		</MakeWixForDirTree>
+	</Target>
 </Project>

--- a/src/Installer/Installer.wixproj
+++ b/src/Installer/Installer.wixproj
@@ -1,4 +1,4 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <ProductVersion>3.0</ProductVersion>
@@ -65,13 +65,13 @@
   </ItemGroup>
   <ItemGroup>
     <WixExtension Include="WixUtilExtension">
-      <HintPath>C:\Program Files\Windows Installer XML v3.5\bin\WixUtilExtension.dll</HintPath>
+      <HintPath>%WIX%\bin\WixUtilExtension.dll</HintPath>
     </WixExtension>
     <WixExtension Include="WixNetFxExtension">
-      <HintPath>C:\Program Files\Windows Installer XML v3.5\bin\WixNetFxExtension.dll</HintPath>
+      <HintPath>%WIX%\bin\WixNetFxExtension.dll</HintPath>
     </WixExtension>
     <WixExtension Include="WixUIExtension">
-      <HintPath>C:\Program Files\Windows Installer XML v3.5\bin\WixUIExtension.dll</HintPath>
+      <HintPath>%WIX%\bin\WixUIExtension.dll</HintPath>
     </WixExtension>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets" />

--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- These variables define the Windows Installer product version, product code and upgrade code. They   -->
-<!-- will be used later on in this file.  this value should be B U I  LD_SCRIPT_MUST_REPLACE_AT_RUNTIME (in quotes) -->
-<?define Property_ProductVersion = "BUILD_SCRIPT_MUST_REPLACE_AT_RUNTIME" ?>
+<!-- These variables define the Windows Installer product code and upgrade code. -->
 
 <!-- * means auto-generate a new guid each time. This is "a unique identifier for the particular product release" -->
 <?define Property_ProductCode = "*" ?>
@@ -15,7 +13,7 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
 
 	<Product Id="$(var.Property_ProductCode)" Name="PdfDroplet $(var.Property_ProductVersion)" Language="1033"
-			   Version="$(var.Property_ProductVersion)" Manufacturer="SIL"
+			   Version="$(var.Property_ProductVersion)" Manufacturer="SIL International"
 			   UpgradeCode="$(var.Property_UpgradeCode)">
 
 		<Package  Compressed="yes" InstallerVersion="200" />
@@ -46,9 +44,9 @@ users to install just the shortcut for your app, then demand-install the
 rest of the app the first time the icon is run.  If this is not behavior you
 are trying to support, you're better off using non-advertised shortcuts. "-->
 
-		<PropertyRef Id="NETFRAMEWORK35" />
-		<Condition Message="Before PdfDroplet can install, you need to install Microsoft's free .NET Framework 3.5.  A full discussion of PdfDroplets's requirements can be found at PdfDroplet.palaso.org.">
-			Installed OR NETFRAMEWORK35
+		<PropertyRef Id="WIX_IS_NETFRAMEWORK_461_OR_LATER_INSTALLED"/>
+		<Condition Message="Before PdfDroplet can install, you need to install Microsoft's free .NET Framework v4.6.1 or greater.  A full discussion of PdfDroplets's requirements can be found at PdfDroplet.palaso.org.">
+			Installed OR WIX_IS_NETFRAMEWORK_461_OR_LATER_INSTALLED
 		</Condition>
 
 		<!--because of bug, this needs to be 1 -->

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("6279fa5d-bd4e-4e41-8150-680c9b4e7fc3")]
 
 //these are set dynamically by the build process; the numbers here are ignored.
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("2.4.6.0")]
+[assembly: AssemblyFileVersion("2.4.6.0")]


### PR DESCRIPTION
- Change manufacturer to SIL International
- Check for .NET framework 4.6.1 or later
- Change WiX hint paths to %WIX%
- Use vswhere to locate Visual Studio in the test installer script
- Pass the product version as a parameter to the WiX build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/pdfdroplet/13)
<!-- Reviewable:end -->
