### PR TITLE
Fix NuGet to always enable TLS 1.2

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -119,6 +119,9 @@
                 try {
                     OutputFilename = Path.GetFullPath(OutputFilename);
 
+                    ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+                    Log.LogMessage("Enabled Protocols: "+ServicePointManager.SecurityProtocol);
+
                     Log.LogMessage("Downloading latest version of NuGet.exe...");
                     WebClient webClient = new WebClient();
                     webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/NuGet.exe", OutputFilename);


### PR DESCRIPTION
This is needed for TeamCity Windows 7 based build agents.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/pdfdroplet/20)
<!-- Reviewable:end -->
