### PR TITLE
Add trimBoxDelta argument to NullLayoutMethod constructor

### DIFF
--- a/src/LayoutMethods/Layouter.cs
+++ b/src/LayoutMethods/Layouter.cs
@@ -118,7 +118,7 @@ namespace PdfDroplet.LayoutMethods
 
 		    if (Settings.Default.Mirror)
             {
-                Matrix mirrorMatrix = new Matrix(-1, 0, 0, 1, 0, 0);
+                var mirrorMatrix = new XMatrix(-1, 0, 0, 1, 0, 0);
                 gfx.MultiplyTransform(mirrorMatrix);
                 gfx.TranslateTransform(-_paperWidth, 1);
             }

--- a/src/LayoutMethods/NullLayoutMethod.cs
+++ b/src/LayoutMethods/NullLayoutMethod.cs
@@ -4,23 +4,37 @@ using System.IO;
 using SIL.IO;
 using PdfSharp.Drawing;
 using PdfSharp.Pdf;
+using PdfSharp.Pdf.IO;
 
 namespace PdfDroplet.LayoutMethods
 {
+	/// <summary>
+	/// Pass the input PDF file along to the output, optionally setting the TrimBox, ArtBox, and BleedBox
+	/// to a smaller size offset inside the MediaBox (and CropBox).
+	/// </summary>
     public class NullLayoutMethod :LayoutMethod
     {
-        public NullLayoutMethod() : base("")
-        {
-        }
+		protected double _bleedMM;
+		private const double kBleedMicroDeltaMM = 0.01; // use for floating point comparisons instead of 0.0
+
+		/// <summary>
+		/// bleedMM is the amount in mm to offset the TrimBox et al. inside the MediaBox.  The default is 0mm
+		/// (TrimBox the same as the MediaBox).
+		/// </summary>
+		/// <param name="bleedMM"></param>
+		public NullLayoutMethod(double bleedMM=0.0) : base("")
+		{
+			_bleedMM = bleedMM;
+		}
 
 		public override void Layout(XPdfForm inputPdf, string inputPath, string outputPath, PaperTarget paperTarget, bool rightToLeft, bool showCropMarks)
         {
-            if (!showCropMarks)
-            {
-	            File.Copy(inputPath, outputPath,true); // we don't have any value to add, so just deliver a copy of the original
-            }
-            else
-            {
+	        if (!showCropMarks && Math.Abs(_bleedMM) < kBleedMicroDeltaMM)
+	        {
+		        File.Copy(inputPath, outputPath, true); // we don't have any value to add, so just deliver a copy of the original
+	        }
+			else
+			{
 				//_rightToLeft = rightToLeft;
 				_inputPdf = inputPdf;
 				_showCropMarks = showCropMarks;
@@ -28,14 +42,16 @@ namespace PdfDroplet.LayoutMethods
 	            PdfDocument outputDocument = new PdfDocument();
 				outputDocument.PageLayout = PdfPageLayout.SinglePage;
 
-	            _paperWidth = _inputPdf.PixelWidth;
-				_paperHeight =_inputPdf.PixelHeight;
-//	            if (showCropMarks)
-//	            {
-//					_paperWidth.Millimeter += (2.0 * LayoutMethod.kMillimetersBetweenTrimAndMediaBox);
-//					_paperHeight.Millimeter += (2.0 * LayoutMethod.kMillimetersBetweenTrimAndMediaBox);
-//	            }
-	            for (int idx = 1; idx <= _inputPdf.PageCount; idx++)
+				// Despite the name, PixelWidth is the same as PointWidth, just as an integer instead of
+				// double precision.  We may as well use all the precision we can get.
+				_paperWidth = _inputPdf.PointWidth;
+				_paperHeight =_inputPdf.PointHeight;
+
+				// NB: Setting outputDocument.Settings.TrimMargins.All does not do what we want: it either
+				// shrinks or expands the MediaBox/CropBox/BleedBox sizes.  It does not change either
+				// TrimBox or ArtBox.
+
+				for (int idx = 1; idx <= _inputPdf.PageCount; idx++)
 	            {
 		            using (XGraphics gfx = GetGraphicsForNewPage(outputDocument))
 		            {
@@ -43,7 +59,34 @@ namespace PdfDroplet.LayoutMethods
 		            }
 	            }
 
-	            outputDocument.Save(outputPath);
+				if (Math.Abs(_bleedMM) > kBleedMicroDeltaMM)
+				{
+					var tempPath = Path.ChangeExtension(Path.Combine(Path.GetDirectoryName(outputPath),
+						Path.GetRandomFileName()), "pdf");
+					outputDocument.Save(tempPath);
+					outputDocument.Close();
+					outputDocument = PdfReader.Open(tempPath, PdfDocumentOpenMode.Import);
+					var bleedMargin = new XUnit(_bleedMM, XGraphicsUnit.Millimeter);
+					PdfDocument realOutput = new PdfDocument();
+					realOutput.PageLayout = PdfPageLayout.SinglePage;
+					var trimLocation = new XPoint(bleedMargin.Point, bleedMargin.Point);
+					foreach (var page in outputDocument.Pages)
+					{
+						var trimBox = new PdfRectangle(trimLocation, new XSize(page.MediaBox.Width - 2 * bleedMargin.Point, page.MediaBox.Height - 2 * bleedMargin.Point));
+						// Leave CropBox the same as MediaBox.  It limits what you see in Adobe Acrobat Reader DC and maybe elsewhere.
+						page.BleedBox = trimBox;
+						page.ArtBox = trimBox;
+						page.TrimBox = trimBox;
+						realOutput.AddPage(page);
+					}
+					outputDocument.Close();
+					File.Delete(tempPath);
+					realOutput.Save(outputPath);
+				}
+				else
+				{
+					outputDocument.Save(outputPath);
+				}
             }
         }
 

--- a/src/PdfDroplet.csproj
+++ b/src/PdfDroplet.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -63,7 +63,7 @@
       <HintPath>..\lib\SIL.Core.dll</HintPath>
     </Reference>
     <Reference Include="PdfSharp">
-      <HintPath>..\packages\PDFsharp.1.32.3057.0\lib\net20\PdfSharp.dll</HintPath>
+      <HintPath>..\packages\PDFsharp.1.50.5147\lib\net20\PdfSharp.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core.Desktop">
       <HintPath>..\lib\SIL.Core.Desktop.dll</HintPath>

--- a/src/WorkSpaceViewModel.cs
+++ b/src/WorkSpaceViewModel.cs
@@ -115,15 +115,8 @@ namespace PdfDroplet
             SelectedMethod = method;
             if (HaveIncomingPdf)
             {
-                if (method is NullLayoutMethod)
-                {
-                    _pathToCurrentlyDisplayedPdf = _incomingPath;
-                    _view.ClearThenContinue(()=>_view.Navigate(_incomingPath)); 
-                }
-                else
-                {
-                    _view.ClearThenContinue(ContinueConversionAndNavigation);
-                }
+                // Handle NullLayoutMethod the same as the others to allow testing crop marks.
+                _view.ClearThenContinue(ContinueConversionAndNavigation);
             }
             if (!string.IsNullOrEmpty(_incomingPath) && Settings.Default.PreviousIncomingPath != _incomingPath)
             {
@@ -198,7 +191,7 @@ namespace PdfDroplet
             }
             catch (Exception error)
             {
-                ErrorReport.NotifyUserOfProblem(error, "PdfBooket was unable to convert that file.");
+                ErrorReport.NotifyUserOfProblem(error, "PdfBooklet was unable to convert that file.");
             }
             _view.UpdateDisplay();
          

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Analytics" version="2.0.2" targetFramework="net461" />
   <package id="DesktopAnalytics" version="1.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
-  <package id="PdfSharp" version="1.32.3057" targetFramework="net461" />
+  <package id="PdfSharp" version="1.50.5147" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This allows callers to set the ArtBox and TrimBox to the original paper
size while increasing the output paper size accordingly.  (That's how
PdfSharp works.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/pdfdroplet/21)
<!-- Reviewable:end -->
